### PR TITLE
Fix the link to VGG16-7

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,4 +8,4 @@ cd ../..
 rm -r large_models large_models.zip 
 
 gunzip benchmarks/*/onnx/* benchmarks/*/vnnlib/*
-wget https://github.com/onnx/models/raw/main/vision/classification/vgg/model/vgg16-7.onnx -O benchmarks/vggnet16_2022/onnx/vgg16-7.onnx
+wget https://github.com/onnx/models/raw/5faef4c33eba0395177850e1e31c4a6a9e634c82/vision/classification/vgg/model/vgg16-7.onnx -O benchmarks/vggnet16_2022/onnx/vgg16-7.onnx


### PR DESCRIPTION
The link to the VGG16-7 model has been broken due to a recent chnage in the onnx/models repo. This PR fixes the issue.
